### PR TITLE
Fix serial configuration. 7-bits is not supported.

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -29,19 +29,6 @@
 
 typedef enum
 {
-    SERIAL_7N1,
-    SERIAL_7N2,
-    SERIAL_7E1,
-    SERIAL_7E2,
-    SERIAL_7O1,
-    SERIAL_7O2,
-    SERIAL_7N0_5,
-    SERIAL_7N1_5,
-    SERIAL_7E0_5,
-    SERIAL_7E1_5,
-    SERIAL_7O0_5,
-    SERIAL_7O1_5,
-
     SERIAL_8N1,
     SERIAL_8N2,
     SERIAL_8E1,


### PR DESCRIPTION
When configuring the serial port it was erroneously selecting the wrong mode.
For example when selecting 8N1 was actually configuring 9N1. Fixed by removing
the invalid 7-bit modes.