### PR TITLE
String: Fix remove method

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -735,7 +735,7 @@ void String::remove(unsigned int index, unsigned int count)
     }
     char *writeTo = buffer + index;
     len = len - count;
-    strncpy(writeTo, buffer + index + count, len - index);
+    memmove(writeTo, buffer + index + count, len - index);
     buffer[len] = 0;
 }
 


### PR DESCRIPTION
strncpy() can not use overlapped memory regions and generates corrupted data with certain inputs. Changed to memmove. Verified with fuzzing against std::string::erase.